### PR TITLE
Fix Docker build by adding missing client package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "client",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.30.1",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.6.0",
+    "eslint": "^9.30.1",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.20",
+    "globals": "^16.3.0",
+    "vite": "^7.0.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add missing React package.json so Docker build can install client dependencies

## Testing
- `npm install --ignore-scripts` in `client`
- `npm run build` in `client`
- `npm install --omit=dev` in `server`
- `node server.js` and `curl http://localhost:3001/api/events`

------
https://chatgpt.com/codex/tasks/task_e_687e23271cfc832886b12700a6829ec2