### PR TITLE
Add navigation layout and profile editing

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -37,3 +37,45 @@ export async function getEvents(token) {
   if (!res.ok) throw new Error('failed');
   return res.json();
 }
+
+export async function createEvent(title, token) {
+  const res = await fetch(`${API_URL}/events`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({title})
+  });
+  if (!res.ok) throw new Error('failed');
+  return res.json();
+}
+
+export async function getMyItems(token) {
+  const res = await fetch(`${API_URL}/my-items`, {
+    headers: {Authorization: `Bearer ${token}`}
+  });
+  if (!res.ok) throw new Error('failed');
+  return res.json();
+}
+
+export async function getMe(token) {
+  const res = await fetch(`${API_URL}/me`, {
+    headers: {Authorization: `Bearer ${token}`}
+  });
+  if (!res.ok) throw new Error('failed');
+  return res.json();
+}
+
+export async function updateMe(data, token) {
+  const res = await fetch(`${API_URL}/me`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) throw new Error('failed');
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add JWT helper and new API calls
- restrict event creation to teachers and admins
- expose `my-items` and `me` API endpoints
- implement top bar, sidebar and profile editing UI
- show tasks and allow creating events

## Testing
- `npm run build` in `client`
- `node server.js` in `server`


------
https://chatgpt.com/codex/tasks/task_e_687e2f1984208328a427fb8ca191d1cb