### PR TITLE
Add event detail view

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -67,6 +67,23 @@ export async function createEvent(title, token) {
   return res.json();
 }
 
+export async function getEventItems(eventId, token) {
+  const res = await fetch(`${API_URL}/events/${eventId}/items`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) throw new Error('failed');
+  return res.json();
+}
+
+export async function takeItem(id, token) {
+  const res = await fetch(`${API_URL}/items/${id}/take`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) throw new Error('failed');
+  return res.json();
+}
+
 export async function getMyItems(token) {
   const res = await fetch(`${API_URL}/my-items`, {
     headers: {Authorization: `Bearer ${token}`}

--- a/server/server.js
+++ b/server/server.js
@@ -145,7 +145,10 @@ app.post('/api/login', (req, res) => {
 });
 
 app.get('/api/events', auth, (req, res) => {
-  db.all('SELECT * FROM events WHERE school_id = ?', [req.user.school_id], (err, rows) => {
+  const sql = `SELECT events.*, users.username AS teacher
+               FROM events JOIN users ON events.created_by = users.id
+               WHERE events.school_id = ?`;
+  db.all(sql, [req.user.school_id], (err, rows) => {
     if (err) return res.status(500).json({error: err.message});
     res.json(rows);
   });
@@ -163,7 +166,11 @@ app.post('/api/events', auth, (req, res) => {
 });
 
 app.get('/api/events/:id/items', auth, (req, res) => {
-  db.all('SELECT * FROM items WHERE event_id = ?', [req.params.id], (err, rows) => {
+  const sql = `SELECT items.id, items.description, items.taken_by,
+                      users.username AS taken_by_username
+               FROM items LEFT JOIN users ON items.taken_by = users.id
+               WHERE items.event_id = ?`;
+  db.all(sql, [req.params.id], (err, rows) => {
     if (err) return res.status(500).json({error: err.message});
     res.json(rows);
   });


### PR DESCRIPTION
## Summary
- show teacher name on events API
- allow querying items with responsible user name
- add API helpers for event detail
- display events as buttons and open new detail view

## Testing
- `npm run build` in `client`
- `node server.js` *(fails: server terminates automatically after startup)*

------
https://chatgpt.com/codex/tasks/task_e_687e4ee2d334832885536525acfc0f9e