### PR TITLE
Fix Docker build by copying source before build

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install && npm run build
+RUN npm install
 COPY public ./public
 COPY src ./src
+RUN npm run build
 EXPOSE 3000
 CMD ["npx","serve","-s","dist","-l","3000"]


### PR DESCRIPTION
## Summary
- fix build order in client Dockerfile so build step has source files available

## Testing
- `npm run build` in `client`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_687eb20bc65883288376d8823cde5dde