### PR TITLE
Add root endpoint and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Ohne Freischaltung ist kein Login möglich.
 1. `npm install` um Abhängigkeiten zu installieren.
 2. `npm test` führt die Jest Tests aus.
 3. `npm start` startet den Express Server.
+   Danach ist unter `http://localhost:3000/` eine kurze Begrüßungsnachricht erreichbar.
 
 ## Docker Deployment
 

--- a/server.js
+++ b/server.js
@@ -15,6 +15,11 @@ app.use(express.json());
 app.use(helmet());
 app.use(cors());
 
+// basic health check
+app.get('/', (req, res) => {
+  res.json({ message: 'Mitplan API' });
+});
+
 const limiter = rateLimit({
   windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000,
   max: parseInt(process.env.RATE_LIMIT_REQUESTS) || 100

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,13 +1,12 @@
 const request = require('supertest');
 const fs = require('fs');
 const path = require('path');
-process.env.DATABASE_PATH = path.join(__dirname, '../data/test.db');
+process.env.DATABASE_PATH = ':memory:';
 const app = require('../server');
 const { db } = require('../db');
 
 afterAll(() => {
   db.close();
-  fs.unlinkSync(process.env.DATABASE_PATH);
 });
 
 describe('auth flow', () => {

--- a/tests/root.test.js
+++ b/tests/root.test.js
@@ -1,0 +1,18 @@
+const request = require('supertest');
+const path = require('path');
+const fs = require('fs');
+process.env.DATABASE_PATH = ':memory:';
+const app = require('../server');
+const { db } = require('../db');
+
+afterAll(() => {
+  db.close();
+});
+
+describe('root endpoint', () => {
+  it('returns welcome message', async () => {
+    const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe('Mitplan API');
+  });
+});


### PR DESCRIPTION
## Summary
- add `/` health check endpoint
- update docs about the welcome message
- use in-memory database for tests
- add regression test for `/`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f587e89d883288f83cc0383471dc1