### PR TITLE
Serve frontend at root

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,13 +16,11 @@ app.use(express.json());
 app.use(helmet());
 app.use(cors());
 
-// basic health check
-app.get('/', (req, res) => {
+// health check under /api
+app.get('/api', (req, res) => {
   res.json({ message: 'Mitplan API' });
 });
 
-// serve frontend under /app
-app.use('/app', express.static(path.join(__dirname, 'public')));
 
 const limiter = rateLimit({
   windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000,
@@ -112,8 +110,11 @@ app.post('/api/events', authenticate,
       });
   });
 
+// serve frontend
+app.use(express.static(path.join(__dirname, 'public')));
+
 // SPA fallback for client routes
-app.get('/app/*', (req, res) => {
+app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 

--- a/tests/root.test.js
+++ b/tests/root.test.js
@@ -10,8 +10,16 @@ afterAll(() => {
 });
 
 describe('root endpoint', () => {
-  it('returns welcome message', async () => {
+  it('serves the frontend application', async () => {
     const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/html/);
+  });
+});
+
+describe('api health endpoint', () => {
+  it('returns welcome message', async () => {
+    const res = await request(app).get('/api');
     expect(res.statusCode).toBe(200);
     expect(res.body.message).toBe('Mitplan API');
   });


### PR DESCRIPTION
## Summary
- serve the React build on the root route
- add `/api` health-check route
- update root endpoint tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f60a5a8a08328a26d8e15490c8b57